### PR TITLE
Script to update github resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __sapper__
 .backup
 .netlify
+.env

--- a/data/resources.yml
+++ b/data/resources.yml
@@ -1,27 +1,25 @@
-# notes
-# - required fields are name, url
-# - a resource name in `backticks` signals it's the NPM package name
-# - prefer existing tags when possible
-
 resources:
-  # TODO consider removing these official links or improve their UX
   - name: svelte.dev
-    url: https://svelte.dev/
+    url: "https://svelte.dev/"
     tags:
       - official
   - name: "`svelte`"
-    url: https://github.com/sveltejs/svelte
+    url: "https://github.com/sveltejs/svelte"
     description: Cybernetically enhanced web apps
     tags:
       - official
+    stars: 24582
+    last_updated: "2019-10-11T06:57:39Z"
   - name: "`sapper`"
-    url: https://github.com/sveltejs/sapper
-    description: Military-grade progressive web apps, powered by Svelte
+    url: "https://github.com/sveltejs/sapper"
+    description: "Military-grade progressive web apps, powered by Svelte"
     tags:
       - official
       - web app frameworks
+    stars: 3452
+    last_updated: "2019-10-11T06:57:29Z"
   - name: integrations
-    url: https://github.com/sveltejs/integrations
+    url: "https://github.com/sveltejs/integrations"
     description: Ways to incorporate Svelte into your stack
     tags:
       - official
@@ -29,1195 +27,1592 @@ resources:
       - preprocessors
       - bundler plugins
       - other lists and resources
+    stars: 257
+    last_updated: "2019-10-06T07:36:56Z"
   - name: branding
-    url: https://github.com/sveltejs/branding
+    url: "https://github.com/sveltejs/branding"
     description: Logos etc for Svelte and related projects
     tags:
       - official
+    stars: 9
+    last_updated: "2019-09-23T18:20:34Z"
   - name: rfcs
-    url: https://github.com/sveltejs/rfcs
+    url: "https://github.com/sveltejs/rfcs"
     description: RFCs for changes to Svelte
     tags:
       - official
+    stars: 61
+    last_updated: "2019-10-10T06:47:56Z"
   - name: community
-    url: https://github.com/sveltejs/community
+    url: "https://github.com/sveltejs/community"
     description: A repo for data relating to the Svelte community and events
     tags:
       - official
       - other lists and resources
       - communities
+    stars: 13
+    last_updated: "2019-10-11T05:57:01Z"
   - name: ru.svelte.dev
-    url: https://ru.svelte.dev/
-    description: "Official site translated into Russian - AlexxNB/svelte3-translation-ru"
+    url: "https://ru.svelte.dev/"
+    description: Official site translated into Russian - AlexxNB/svelte3-translation-ru
     tags:
       - official
       - language translations
   - name: Discord chat
-    url: https://svelte.dev/chat
+    url: "https://svelte.dev/chat"
     tags:
       - official
       - communities
   - name: "@sveltejs on Twitter"
-    url: https://twitter.com/sveltejs
+    url: "https://twitter.com/sveltejs"
     tags:
       - official
       - communities
   - name: /r/sveltejs
-    url: https://www.reddit.com/r/sveltejs/
+    url: "https://www.reddit.com/r/sveltejs/"
     tags:
       - communities
   - name: ":ru: Svelte [svelt]"
-    url: https://t.me/sveltejs) (1000+ users
+    url: "https://t.me/sveltejs) (1000+ users"
     tags:
       - communities
       - Telegram chat rooms
   - name: ":ru: Svelte [svelt] Public"
-    url: https://t.me/sveltejs_public
+    url: "https://t.me/sveltejs_public"
     tags:
       - communities
       - Telegram chat rooms
   - name: ":ru: Svelte [svelt] Jobs"
-    url: https://t.me/sveltejs_jobs
+    url: "https://t.me/sveltejs_jobs"
     tags:
       - communities
       - Telegram chat rooms
   - name: "`svelte-loader`"
-    url: https://github.com/sveltejs/svelte-loader
+    url: "https://github.com/sveltejs/svelte-loader"
     description: Webpack loader for Svelte components
     tags:
       - integrations
       - bundler plugins
+    stars: 243
+    last_updated: "2019-10-09T11:14:08Z"
   - name: "`rollup-plugin-svelte`"
-    url: https://github.com/rollup/rollup-plugin-svelte
+    url: "https://github.com/rollup/rollup-plugin-svelte"
     description: Compile Svelte components with Rollup
     tags:
       - integrations
       - bundler plugins
+    stars: 137
+    last_updated: "2019-10-05T18:07:08Z"
   - name: "`svelte-preprocess`"
-    url: https://github.com/kaisermann/svelte-preprocess
+    url: "https://github.com/kaisermann/svelte-preprocess"
     description: A Svelte preprocessor with baked in support for common preprocessors
     tags:
       - integrations
       - preprocessors
+    stars: 240
+    last_updated: "2019-10-09T17:44:40Z"
   - name: "`mdsvex`"
-    url: https://github.com/pngwn/MDsveX
+    url: "https://github.com/pngwn/MDsveX"
     description: A markdown preprocessor for Svelte
     tags:
       - integrations
       - preprocessors
+    stars: 143
+    last_updated: "2019-10-10T18:39:12Z"
   - name: "`svelte-ts-preprocess`"
-    url: https://github.com/PaulMaly/svelte-ts-preprocess
+    url: "https://github.com/PaulMaly/svelte-ts-preprocess"
     description: Typescript preprocessor for Svelte 3
     tags:
       - integrations
       - preprocessors
+    stars: 82
+    last_updated: "2019-10-08T14:15:19Z"
   - name: "`@pyoner/svelte-ts-preprocess`"
-    url: https://github.com/pyoner/svelte-typescript
-    description: Typescript monorepo for Svelte v3 (preprocess, template, types)
+    url: "https://github.com/pyoner/svelte-typescript"
+    description: "Typescript monorepo for Svelte v3 (preprocess, template, types)"
     tags:
       - integrations
       - preprocessors
+    stars: 93
+    last_updated: "2019-10-10T16:58:39Z"
   - name: "`svelte-preprocess-postcss`"
-    url: https://github.com/TehShrike/svelte-preprocess-postcss
+    url: "https://github.com/TehShrike/svelte-preprocess-postcss"
     description: PostCSS preprocessor
     tags:
       - integrations
       - preprocessors
+    stars: 16
+    last_updated: "2019-09-03T20:46:15Z"
   - name: "`svelte-preprocess-sass`"
-    url: https://github.com/ls-age/svelte-preprocess-sass
+    url: "https://github.com/ls-age/svelte-preprocess-sass"
     description: SASS/SCSS preprocessor
     tags:
       - integrations
       - preprocessors
+    stars: 41
+    last_updated: "2019-10-10T14:44:51Z"
   - name: "`svelte-preprocess-less`"
-    url: https://github.com/ls-age/svelte-preprocess-less
+    url: "https://github.com/ls-age/svelte-preprocess-less"
     description: LESS preprocessor
     tags:
       - integrations
       - preprocessors
+    stars: 4
+    last_updated: "2019-10-05T07:50:17Z"
   - name: "`@modular-css/svelte`"
-    url: https://github.com/tivac/modular-css/tree/master/packages/svelte
+    url: "https://github.com/tivac/modular-css/tree/master/packages/svelte"
     description: "`modular-css` preprocessor"
     tags:
       - integrations
       - preprocessors
   - name: "`@pwa/cli`"
-    url: https://github.com/lukeed/pwa
+    url: "https://github.com/lukeed/pwa"
     description: Universal PWA Builder (WIP)
     tags:
       - integrations
       - cli tools
+    stars: 2795
+    last_updated: "2019-10-04T19:32:00Z"
   - name: "`baelte`"
-    url: https://github.com/kennethlarsen/baelte
+    url: "https://github.com/kennethlarsen/baelte"
     description: CLI tool for svelte to help you be productive
     tags:
       - integrations
       - cli tools
+    stars: 53
+    last_updated: "2019-10-09T16:39:20Z"
   - name: "`svb`"
-    url: https://github.com/himynameisdave/svb
+    url: "https://github.com/himynameisdave/svb"
     description: A zero-config CLI to bundle Svelte apps (WIP)
     tags:
       - integrations
       - cli tools
+    stars: 15
+    last_updated: "2019-09-30T10:06:43Z"
   - name: svelte-vscode
-    url: https://github.com/UnwrittenFun/svelte-vscode
+    url: "https://github.com/UnwrittenFun/svelte-vscode"
     description: Svelte language support for VS Code
     tags:
       - integrations
       - editor tools
+    stars: 131
+    last_updated: "2019-10-10T13:08:29Z"
   - name: vim-svelte
-    url: https://github.com/evanleck/vim-svelte
+    url: "https://github.com/evanleck/vim-svelte"
     description: Svelte JavaScript syntax highlighting for vim
     tags:
       - integrations
       - editor tools
+    stars: 44
+    last_updated: "2019-10-08T08:11:55Z"
   - name: vim-svelte-plugin
-    url: https://github.com/leafOfTree/vim-svelte-plugin
+    url: "https://github.com/leafOfTree/vim-svelte-plugin"
     description: Vim syntax and indent plugin for .svelte files
     tags:
       - integrations
       - editor tools
+    stars: 5
+    last_updated: "2019-10-11T04:55:24Z"
   - name: svelte-intellij
-    url: https://github.com/tomblachut/svelte-intellij
+    url: "https://github.com/tomblachut/svelte-intellij"
     description: Provides syntax highlighting of Svelte components in WebStorm and friends
     tags:
       - integrations
       - editor tools
+    stars: 110
+    last_updated: "2019-10-09T11:55:39Z"
   - name: "`svelte-language-server`"
-    url: https://github.com/UnwrittenFun/svelte-language-server
+    url: "https://github.com/UnwrittenFun/svelte-language-server"
     description: A WIP language server for Svelte
     tags:
       - integrations
       - editor tools
+    stars: 60
+    last_updated: "2019-10-09T11:29:23Z"
   - name: vscode-svelte-component-extractor
-    url: https://github.com/proverbial-ninja/vscode-svelte-component-extractor
+    url: "https://github.com/proverbial-ninja/vscode-svelte-component-extractor"
     description: Creates a new Svelte component from higlighted text
     tags:
       - integrations
       - editor tools
+    stars: 10
+    last_updated: "2019-09-09T18:46:36Z"
   - name: coc-svelte
-    url: https://github.com/coc-extensions/coc-svelte
+    url: "https://github.com/coc-extensions/coc-svelte"
     description: Svelte support for (Neo)Vim
     tags:
       - integrations
       - editor tools
+    stars: 2
+    last_updated: "2019-10-05T14:31:00Z"
   - name: sveltejs/template
-    url: https://github.com/sveltejs/template
+    url: "https://github.com/sveltejs/template"
     description: Template for building basic applications with Svelte with rollup
     tags:
       - templates
+    stars: 255
+    last_updated: "2019-10-10T02:54:01Z"
   - name: sveltejs/template-webpack
-    url: https://github.com/sveltejs/template-webpack
+    url: "https://github.com/sveltejs/template-webpack"
     description: Template for building basic Svelte applications with webpack
     tags:
       - templates
+    stars: 119
+    last_updated: "2019-10-04T13:51:32Z"
   - name: sveltejs/component-template
-    url: https://github.com/sveltejs/component-template
+    url: "https://github.com/sveltejs/component-template"
     description: A base for building shareable Svelte components
     tags:
       - templates
+    stars: 108
+    last_updated: "2019-10-09T18:03:03Z"
   - name: sveltejs/template-custom-element
-    url: https://github.com/sveltejs/template-custom-element
+    url: "https://github.com/sveltejs/template-custom-element"
     description: Template for building basic applications with Svelte and custom elements
     tags:
       - templates
+    stars: 14
+    last_updated: "2019-09-16T04:16:13Z"
   - name: sveltejs/sapper-template
-    url: https://github.com/sveltejs/sapper-template
+    url: "https://github.com/sveltejs/sapper-template"
     description: Starter template for Sapper apps
     tags:
       - templates
+    stars: 326
+    last_updated: "2019-10-11T06:55:06Z"
   - name: pyoner/svelte-typescript
-    url: https://github.com/pyoner/svelte-typescript
-    description: Typescript monorepo for Svelte v3 (preprocess, template, types)
+    url: "https://github.com/pyoner/svelte-typescript"
+    description: "Typescript monorepo for Svelte v3 (preprocess, template, types)"
     tags:
       - templates
+    stars: 93
+    last_updated: "2019-10-10T16:58:39Z"
   - name: Axelen123/svelte-ts-template
-    url: https://github.com/Axelen123/svelte-ts-template
+    url: "https://github.com/Axelen123/svelte-ts-template"
     description: Typescript template for Svelte v3
     tags:
       - templates
+    stars: 16
+    last_updated: "2019-09-24T16:59:33Z"
   - name: Shyam-Chen/svelte-play
-    url: https://github.com/Shyam-Chen/Svelte-Play
-    description: A boilerplate with Material, Babel, PostCSS, and Webpack
+    url: "https://github.com/Shyam-Chen/Svelte-Play"
+    description: "A boilerplate with Material, Babel, PostCSS, and Webpack"
     tags:
       - templates
+    stars: 76
+    last_updated: "2019-09-04T01:26:41Z"
   - name: Holben888/svelte-starter-template
-    url: https://github.com/Holben888/svelte-starter-template
+    url: "https://github.com/Holben888/svelte-starter-template"
     description: A small starter template to get up and running with Svelte v3
     tags:
       - templates
+    stars: 22
+    last_updated: "2019-10-11T04:48:39Z"
   - name: marcograhl/tailwindcss-svelte-starter
-    url: https://github.com/marcograhl/tailwindcss-svelte-starter
+    url: "https://github.com/marcograhl/tailwindcss-svelte-starter"
     description: Tailwindcss v1 + Svelte v3 = <3
     tags:
       - templates
+    stars: 46
+    last_updated: "2019-10-09T20:29:26Z"
   - name: muhajirdev/svelte-tailwind-template
-    url: https://github.com/muhajirdev/svelte-tailwind-template
+    url: "https://github.com/muhajirdev/svelte-tailwind-template"
     description: Svelte + Tailwind = ❤
     tags:
       - templates
+    stars: 44
+    last_updated: "2019-10-06T13:22:52Z"
   - name: fabiohvp/svelte-template
-    url: https://github.com/fabiohvp/svelte-template
+    url: "https://github.com/fabiohvp/svelte-template"
     description: Svelte with materializecss + tailwindcss
     tags:
       - templates
+    stars: 3
+    last_updated: "2019-10-04T17:02:32Z"
   - name: justinekizhak/svelte-tailwind-template
-    url: https://github.com/justinekizhak/svelte-tailwind-template
+    url: "https://github.com/justinekizhak/svelte-tailwind-template"
     description: SvelteJS and TailwindCSS template
     tags:
       - templates
+    stars: 0
+    last_updated: "2019-09-09T13:33:24Z"
   - name: geakstr/svelte-3-rollup-typescript-vscode
-    url: https://github.com/geakstr/svelte-3-rollup-typescript-vscode
+    url: "https://github.com/geakstr/svelte-3-rollup-typescript-vscode"
     description: Starter for Svelte 3/rollup/typescript/vscode
     tags:
       - templates
+    stars: 25
+    last_updated: "2019-09-29T03:18:09Z"
   - name: jorgegorka/svelte-firebase
-    url: https://github.com/jorgegorka/svelte-firebase
+    url: "https://github.com/jorgegorka/svelte-firebase"
     description: A template to help you start developing SPAs with Svelte and Firebase
     tags:
       - templates
+    stars: 20
+    last_updated: "2019-10-07T11:21:06Z"
   - name: ricalamino/svelte-firebase-auth
-    url: https://github.com/ricalamino/svelte-firebase-auth
+    url: "https://github.com/ricalamino/svelte-firebase-auth"
     description: Svelte App with Firebase Authentication for all purposes
     tags:
       - templates
+    stars: 10
+    last_updated: "2019-09-03T17:12:15Z"
   - name: YogliB/svelte-component-template
-    url: https://github.com/YogliB/svelte-component-template
+    url: "https://github.com/YogliB/svelte-component-template"
     description: A base for building shareable Svelte 3 components
     tags:
       - templates
+    stars: 72
+    last_updated: "2019-10-10T16:27:43Z"
   - name: neighbourhoodie/svelte-pouchdb-couchdb
-    url: https://github.com/neighbourhoodie/svelte-pouchdb-couchdb
-    description: Offline-Capable todo list built with Svelte, PouchDB and CouchDB
+    url: "https://github.com/neighbourhoodie/svelte-pouchdb-couchdb"
+    description: "Offline-Capable todo list built with Svelte, PouchDB and CouchDB"
     tags:
       - templates
+    stars: 16
+    last_updated: "2019-09-16T04:00:56Z"
   - name: OrdinaryJellyfish/svelte-routing-template
-    url: https://github.com/OrdinaryJellyfish/svelte-routing-template
+    url: "https://github.com/OrdinaryJellyfish/svelte-routing-template"
     description: Svelte webpack template with routing and lazy-loading
     tags:
       - templates
+    stars: 13
+    last_updated: "2019-09-30T10:15:55Z"
   - name: angelozehr/svelte-example-museums
-    url: https://github.com/angelozehr/svelte-example-museums
+    url: "https://github.com/angelozehr/svelte-example-museums"
     description: An example repo of a Svelte app that is IE11 compatible
     tags:
       - templates
+    stars: 8
+    last_updated: "2019-10-05T01:43:23Z"
   - name: pankod/svelte-boilerplate
-    url: https://github.com/pankod/svelte-boilerplate
-    description: Svelte application boilerplate with Webpack, Sass, BabelJS, Fetch,
+    url: "https://github.com/pankod/svelte-boilerplate"
+    description: >-
+      Svelte application boilerplate with Webpack, Sass, BabelJS, Fetch,
       PostCSS, Jest, and .Env
     tags:
       - templates
+    stars: 88
+    last_updated: "2019-10-09T08:32:58Z"
   - name: pbastowski/svelte-poi-starter
-    url: https://github.com/pbastowski/svelte-poi-starter
-    description: Svelte 3 starter with POI 12 and Prettier. Outputs web apps or web
+    url: "https://github.com/pbastowski/svelte-poi-starter"
+    description: >-
+      Svelte 3 starter with POI 12 and Prettier. Outputs web apps or web
       components
     tags:
       - templates
+    stars: 8
+    last_updated: "2019-08-21T21:49:20Z"
   - name: soapdog/svelte-template-browserify
-    url: https://github.com/soapdog/svelte-template-browserify
+    url: "https://github.com/soapdog/svelte-template-browserify"
     description: A Svelte template for browserify
     tags:
       - templates
+    stars: 3
+    last_updated: "2019-08-29T13:09:21Z"
   - name: antony/svelte-box
-    url: https://github.com/antony/svelte-box
-    description: A truffle box for Svelte, a seed for building an Ethereum dapp using
+    url: "https://github.com/antony/svelte-box"
+    description: >-
+      A truffle box for Svelte, a seed for building an Ethereum dapp using
       Truffle
     tags:
       - templates
+    stars: 17
+    last_updated: "2019-08-27T01:10:31Z"
   - name: spaceavocado/svelte-router-template
-    url: https://github.com/spaceavocado/svelte-router-template
+    url: "https://github.com/spaceavocado/svelte-router-template"
     description: Boilerplate template project for SPA router spaceavocado/svelte-router
     tags:
       - templates
+    stars: 5
+    last_updated: "2019-09-30T11:01:01Z"
   - name: beyonk-adventures/svelte-component-livereload-template
-    url: https://github.com/beyonk-adventures/svelte-component-livereload-template
+    url: "https://github.com/beyonk-adventures/svelte-component-livereload-template"
     description: Component template with LiveReload and Jest unit testing
     tags:
       - templates
+    stars: 9
+    last_updated: "2019-09-27T04:10:26Z"
   - name: patoi/svelte-component-library-template
-    url: https://github.com/patoi/svelte-component-library-template
+    url: "https://github.com/patoi/svelte-component-library-template"
     description: A base for building Svelte component library
     tags:
       - templates
+    stars: 16
+    last_updated: "2019-10-10T08:51:29Z"
   - name: brandonxiang/svelte-webpack-mpa
-    url: https://github.com/brandonxiang/svelte-webpack-mpa
+    url: "https://github.com/brandonxiang/svelte-webpack-mpa"
     description: A template to create multi-page application powered by Webpack
     tags:
       - templates
+    stars: 3
+    last_updated: "2019-09-21T09:34:31Z"
   - name: jerriclynsjohn/svelte-storybook-tailwind
-    url: https://github.com/jerriclynsjohn/svelte-storybook-tailwind
+    url: "https://github.com/jerriclynsjohn/svelte-storybook-tailwind"
     description: Svelte + Storybook + Tailwind - Starter Template
     tags:
       - templates
+    stars: 85
+    last_updated: "2019-10-11T07:03:24Z"
   - name: farhan2106/svelte-typescript
-    url: https://github.com/farhan2106/svelte-typescript
+    url: "https://github.com/farhan2106/svelte-typescript"
     description: Typescript + Storybook + Webpack boilerplate
     tags:
       - templates
+    stars: 29
+    last_updated: "2019-10-10T13:27:56Z"
   - name: farhan2106/svelte-typescript-ssr
-    url: https://github.com/farhan2106/svelte-typescript-ssr
+    url: "https://github.com/farhan2106/svelte-typescript-ssr"
     description: Typescript + Storybook + Webpack with SSR boilerplate
     tags:
       - templates
+    stars: 8
+    last_updated: "2019-09-11T08:17:09Z"
   - name: n0th1ng-else/svelte-typescript-sass
-    url: https://github.com/n0th1ng-else/svelte-typescript-sass
+    url: "https://github.com/n0th1ng-else/svelte-typescript-sass"
     description: Boilerplate code with Typescript and Sass bundled by Webpack
     tags:
       - templates
+    stars: 8
+    last_updated: "2019-09-15T05:58:36Z"
   - name: stephanepericat/svelte-boilerplate
-    url: https://github.com/stephanepericat/svelte-boilerplate
-    description: Boilerplate with Webpack, Cypress, Travis CI, Storybook, and SASS
+    url: "https://github.com/stephanepericat/svelte-boilerplate"
+    description: "Boilerplate with Webpack, Cypress, Travis CI, Storybook, and SASS"
     tags:
       - templates
+    stars: 11
+    last_updated: "2019-10-08T01:07:13Z"
   - name: will-wow/svelte-typescript-template
-    url: https://github.com/will-wow/svelte-typescript-template
-    description: Template with TypeScript, Babel, Jest, Svelte-Testing-Library, Eslint, and
+    url: "https://github.com/will-wow/svelte-typescript-template"
+    description: >-
+      Template with TypeScript, Babel, Jest, Svelte-Testing-Library, Eslint, and
       Prettier
     tags:
       - templates
+    stars: 0
+    last_updated: "2019-09-13T01:46:33Z"
   - name: tonyrewin/svelte3-ts-boilerplate
-    url: https://github.com/tonyrewin/svelte3-ts-boilerplate
-    description: Starter pack for Rollup, Typescript, and VSCode
+    url: "https://github.com/tonyrewin/svelte3-ts-boilerplate"
+    description: "Starter pack for Rollup, Typescript, and VSCode"
     tags:
       - templates
+    stars: 1
+    last_updated: "2019-09-27T07:48:08Z"
   - name: devghost/svelte
-    url: https://github.com/devghost/svelte
-    description: Skeleton app with Parcel, Jest, ESLint, Prettier, Babel, Wallaby
+    url: "https://github.com/devghost/svelte"
+    description: "Skeleton app with Parcel, Jest, ESLint, Prettier, Babel, Wallaby"
     tags:
       - templates
+    stars: 1
+    last_updated: "2019-10-01T17:10:17Z"
   - name: SteveALee/svelte-code-cypress-project
-    url: https://github.com/SteveALee/svelte-code-cypress-project
-    description: Template with VSCode, Prettier, ESLint, Cypress, and Rollup
+    url: "https://github.com/SteveALee/svelte-code-cypress-project"
+    description: "Template with VSCode, Prettier, ESLint, Cypress, and Rollup"
     tags:
       - templates
+    stars: 0
+    last_updated: "2019-10-03T08:30:54Z"
   - name: rixo/svelte-template-hot
-    url: https://github.com/rixo/svelte-template-hot
+    url: "https://github.com/rixo/svelte-template-hot"
     description: Clone of official Svelte template with added HMR support using Nollup
     tags:
       - templates
+    stars: 1
+    last_updated: "2019-10-10T13:45:41Z"
   - name: Rich-Harris/svelte-template-electron
-    url: https://github.com/Rich-Harris/svelte-template-electron
+    url: "https://github.com/Rich-Harris/svelte-template-electron"
     description: A template for building Electron apps with Svelte (**VERSION 2**)
     tags:
       - templates
       - electron templates
+    stars: 34
+    last_updated: "2019-10-02T16:42:33Z"
   - name: Blade67/Sveltron
-    url: https://github.com/Blade67/Sveltron
+    url: "https://github.com/Blade67/Sveltron"
     description: Electron Svelte boilerplate
     tags:
       - templates
       - electron templates
+    stars: 26
+    last_updated: "2019-10-08T02:32:10Z"
   - name: chuanqisun/svelte-electron-template
-    url: https://github.com/chuanqisun/svelte-electron-template
+    url: "https://github.com/chuanqisun/svelte-electron-template"
     description: The bare minimum boilerplate to use Svelte in electron
     tags:
       - templates
       - electron templates
+    stars: 2
+    last_updated: "2019-10-08T02:36:33Z"
   - name: syonip/svelte-cordova
-    url: https://github.com/syonip/svelte-cordova
+    url: "https://github.com/syonip/svelte-cordova"
     description: Starter template for Cordova featuring hot reload
     tags:
       - templates
       - mobile templates
+    stars: 3
+    last_updated: "2019-10-01T22:07:08Z"
   - name: lpshanley/svelte-phonegap
-    url: https://github.com/lpshanley/svelte-phonegap
+    url: "https://github.com/lpshanley/svelte-phonegap"
     description: Template for building phonegap hybrid applications with Svelte
     tags:
       - templates
       - mobile templates
+    stars: 5
+    last_updated: "2019-08-24T12:59:21Z"
   - name: "`@testing-library/svelte`"
-    url: https://github.com/testing-library/svelte-testing-library
+    url: "https://github.com/testing-library/svelte-testing-library"
     description: Simple and complete DOM testing utilities that encourage good practices
     tags:
       - testing
+    stars: 191
+    last_updated: "2019-10-10T11:53:44Z"
   - name: "`jest-transform-svelte`"
-    url: https://github.com/rspieker/jest-transform-svelte
+    url: "https://github.com/rspieker/jest-transform-svelte"
     description: Jest Transformer for Svelte components
     tags:
       - testing
+    stars: 15
+    last_updated: "2019-10-08T06:29:09Z"
   - name: "`svelte-test`"
-    url: https://github.com/pngwn/svelte-test
+    url: "https://github.com/pngwn/svelte-test"
     description: Testing utilities for Svelte
     tags:
       - testing
+    stars: 16
+    last_updated: "2019-08-19T08:59:53Z"
   - name: storybookjs
-    url: https://github.com/storybookjs/storybook
+    url: "https://github.com/storybookjs/storybook"
     description: UI component dev & test
     tags:
       - testing
+    stars: 42027
+    last_updated: "2019-10-11T06:51:19Z"
   - name: "`svelte-jest`"
-    url: https://github.com/ktsn/svelte-jest
+    url: "https://github.com/ktsn/svelte-jest"
     description: Jest Svelte component transformer
     tags:
       - testing
+    stars: 16
+    last_updated: "2019-10-09T06:24:59Z"
   - name: "`svelte-routing`"
-    url: https://github.com/EmilTholin/svelte-routing
+    url: "https://github.com/EmilTholin/svelte-routing"
     description: A declarative Svelte routing library with SSR support
     tags:
       - routers
       - Svelte-specific routing
+    stars: 434
+    last_updated: "2019-10-11T02:00:51Z"
   - name: "`svelte-state-renderer`"
-    url: https://github.com/TehShrike/svelte-state-renderer
+    url: "https://github.com/TehShrike/svelte-state-renderer"
     description: abstract-state-router renderer for Svelte
     tags:
       - routers
       - Svelte-specific routing
+    stars: 24
+    last_updated: "2019-10-02T21:17:35Z"
   - name: "`svelte-spa-router`"
-    url: https://github.com/ItalyPaleAle/svelte-spa-router
+    url: "https://github.com/ItalyPaleAle/svelte-spa-router"
     description: Router for SPAs using Svelte 3
     tags:
       - routers
       - Svelte-specific routing
+    stars: 158
+    last_updated: "2019-10-11T01:55:15Z"
   - name: "`svero`"
-    url: https://github.com/kazzkiq/svero
+    url: "https://github.com/kazzkiq/svero"
     description: A simple router for Svelte 3
     tags:
       - routers
       - Svelte-specific routing
+    stars: 151
+    last_updated: "2019-10-09T16:10:37Z"
   - name: "`swheel`"
-    url: https://github.com/qutran/swheel
+    url: "https://github.com/qutran/swheel"
     description: Ultimate Svelte router
     tags:
       - routers
       - Svelte-specific routing
+    stars: 25
+    last_updated: "2019-09-25T16:30:32Z"
   - name: "`@jamen/svelte-router`"
-    url: https://github.com/jamen/svelte-router
+    url: "https://github.com/jamen/svelte-router"
     description: Svelte router using a store and components
     tags:
       - routers
       - Svelte-specific routing
+    stars: 6
+    last_updated: "2019-08-23T02:10:21Z"
   - name: "`svelte-hash-router`"
-    url: https://github.com/pynnl/svelte-hash-router
+    url: "https://github.com/pynnl/svelte-hash-router"
     description: Simple Svelte 3 hash based router with global routes
     tags:
       - routers
       - Svelte-specific routing
+    stars: 8
+    last_updated: "2019-09-10T19:20:18Z"
   - name: svelte-easyroute
-    url: https://github.com/lyohaplotinka/svelte-easyroute
+    url: "https://github.com/lyohaplotinka/svelte-easyroute"
     description: Easy router for Svelte framework
     tags:
       - routers
       - Svelte-specific routing
+    stars: 35
+    last_updated: "2019-09-17T00:20:41Z"
   - name: "`svelte-router-spa`"
-    url: https://github.com/jorgegorka/svelte-router
+    url: "https://github.com/jorgegorka/svelte-router"
     description: Svelte router specially designed for Single Page Applications (SPA)
     tags:
       - routers
       - Svelte-specific routing
+    stars: 18
+    last_updated: "2019-10-08T06:21:36Z"
   - name: "`@spaceavocado/svelte-router`"
-    url: https://github.com/spaceavocado/svelte-router
+    url: "https://github.com/spaceavocado/svelte-router"
     description: Simple Svelte Router for Single Page Applications (SPA)
     tags:
       - routers
       - Svelte-specific routing
+    stars: 20
+    last_updated: "2019-10-10T13:53:42Z"
   - name: "`svelte-page-router`"
-    url: https://github.com/PaulMaly/svelte-page-router
-    description: Simple config-based router with DX similar to VueRouter. Works well on the
+    url: "https://github.com/PaulMaly/svelte-page-router"
+    description: >-
+      Simple config-based router with DX similar to VueRouter. Works well on the
       server-side
     tags:
       - routers
       - Svelte-specific routing
+    stars: 4
+    last_updated: "2019-09-21T07:33:32Z"
   - name: "`svelte-router`"
-    url: https://github.com/jikkai/svelte-router
+    url: "https://github.com/jikkai/svelte-router"
     description: Router component for Svelte
     tags:
       - routers
       - Svelte-specific routing
+    stars: 53
+    last_updated: "2019-08-29T18:04:48Z"
   - name: "`svelte-navaid`"
-    url: https://github.com/jacwright/svelte-navaid
+    url: "https://github.com/jacwright/svelte-navaid"
     description: A Svelte router powered by lukeed/navaid
     tags:
       - routers
       - Svelte-specific routing
+    stars: 4
+    last_updated: "2019-10-09T02:03:47Z"
   - name: "`@slick-for/svelte`"
-    url: https://github.com/shavyg2/slick-for-svelte
-    description: Manage your views and routing using class decorators and dependency
+    url: "https://github.com/shavyg2/slick-for-svelte"
+    description: >-
+      Manage your views and routing using class decorators and dependency
       injection
     tags:
       - routers
       - Svelte-specific routing
+    stars: 13
+    last_updated: "2019-09-30T09:59:41Z"
   - name: "`crayon-svelte`"
-    url: https://github.com/alshdavid/crayon
+    url: "https://github.com/alshdavid/crayon"
     description: Framework agnostic UI router for SPAs with specific support for Svelte
     tags:
       - routers
       - Svelte-specific routing
+    stars: 232
+    last_updated: "2019-10-09T18:22:13Z"
   - name: "`svelte-filerouter`"
-    url: https://github.com/jakobrosenberg/svelte-filerouter
+    url: "https://github.com/jakobrosenberg/svelte-filerouter"
     description: Filesystem-based router inspired by Sapper's routing
     tags:
       - routers
       - Svelte-specific routing
+    stars: 15
+    last_updated: "2019-10-10T09:26:13Z"
   - name: "`navaid`"
-    url: https://github.com/lukeed/navaid
-    description: A navigation aid (aka, router) for the browser in 850 bytes~!
+    url: "https://github.com/lukeed/navaid"
+    description: "A navigation aid (aka, router) for the browser in 850 bytes~!"
     tags:
       - routers
       - generic routing
+    stars: 376
+    last_updated: "2019-10-11T02:01:43Z"
   - name: "`abstract-state-router`"
-    url: https://github.com/TehShrike/abstract-state-router
-    description: Like ui-router, but without all the Angular. The best way to structure a
+    url: "https://github.com/TehShrike/abstract-state-router"
+    description: >-
+      Like ui-router, but without all the Angular. The best way to structure a
       SPA
     tags:
       - routers
       - generic routing
+    stars: 262
+    last_updated: "2019-10-11T02:03:03Z"
   - name: "`page`"
-    url: https://github.com/visionmedia/page.js/
+    url: "https://github.com/visionmedia/page.js/"
     description: Micro client-side router inspired by the Express router
     tags:
       - routers
       - generic routing
   - name: "`router5`"
-    url: https://github.com/router5/router5
+    url: "https://github.com/router5/router5"
     description: Flexible and powerful universal routing solution
     tags:
       - routers
       - generic routing
+    stars: 1466
+    last_updated: "2019-10-10T20:06:47Z"
   - name: "`svelma`"
-    url: https://github.com/c0bra/svelma
+    url: "https://github.com/c0bra/svelma"
     description: Bulma components for Svelte
     tags:
       - components and libraries
       - ui component sets
+    stars: 147
+    last_updated: "2019-10-11T06:24:49Z"
   - name: "`smelte`"
-    url: https://github.com/matyunya/smelte
+    url: "https://github.com/matyunya/smelte"
     description: Material design components for Svelte using Tailwind CSS
     tags:
       - components and libraries
       - ui component sets
+    stars: 133
+    last_updated: "2019-10-10T20:08:32Z"
   - name: "`svelte-toolbox`"
-    url: https://github.com/svelte-toolbox/svelte-toolbox
-    description: A UI component library for Svelte implementing Google's Material Design
+    url: "https://github.com/svelte-toolbox/svelte-toolbox"
+    description: >-
+      A UI component library for Svelte implementing Google's Material Design
       specification
     tags:
       - components and libraries
       - ui component sets
+    stars: 31
+    last_updated: "2019-10-09T15:57:41Z"
   - name: "`svelte-material-ui`"
-    url: https://github.com/hperrin/svelte-material-ui
+    url: "https://github.com/hperrin/svelte-material-ui"
     description: Svelte Material UI Components
     tags:
       - components and libraries
       - ui component sets
+    stars: 268
+    last_updated: "2019-10-11T00:03:05Z"
   - name: "`svelteify`"
-    url: https://github.com/exybore/svelteify
+    url: "https://github.com/exybore/svelteify"
     description: Material components library for Svelte using the stylesheet of Vuetify
     tags:
       - components and libraries
       - ui component sets
+    stars: 15
+    last_updated: "2019-09-29T19:47:43Z"
   - name: "`sveltemantic`"
-    url: https://github.com/titans-inc/sveltemantic
+    url: "https://github.com/titans-inc/sveltemantic"
     description: Fomantic-UI components for Svelte 3
     tags:
       - components and libraries
       - ui component sets
+    stars: 22
+    last_updated: "2019-10-10T18:35:08Z"
   - name: "`sveltestrap`"
-    url: https://github.com/bestguy/sveltestrap
+    url: "https://github.com/bestguy/sveltestrap"
     description: Bootstrap 4 components for Svelte
     tags:
       - components and libraries
       - ui component sets
+    stars: 122
+    last_updated: "2019-10-11T03:19:58Z"
   - name: "`svelte-ui`"
-    url: https://github.com/vikignt/svelte-ui
+    url: "https://github.com/vikignt/svelte-ui"
     description: Simple Svelte 3 UI components
     tags:
       - components and libraries
       - ui component sets
+    stars: 30
+    last_updated: "2019-10-10T22:52:17Z"
   - name: "`svmd`"
-    url: https://github.com/hkh12/svmd
-    description: Easy-to-use, Customizable Material Design components for Svelte
+    url: "https://github.com/hkh12/svmd"
+    description: "Easy-to-use, Customizable Material Design components for Svelte"
     tags:
       - components and libraries
       - ui component sets
+    stars: 4
+    last_updated: "2019-09-27T07:48:33Z"
   - name: "`svelte-chota`"
-    url: https://github.com/alexxnb/svelte-chota
+    url: "https://github.com/alexxnb/svelte-chota"
     description: Svelte UI components based on super lightweight chota CSS framework.
     tags:
       - components and libraries
       - ui component sets
+    stars: 4
+    last_updated: "2019-10-10T18:38:28Z"
   - name: "`zoo-web-components`"
-    url: https://github.com/zooplus/zoo-web-components
+    url: "https://github.com/zooplus/zoo-web-components"
     description: Web-components library built with Svelte
     tags:
       - components and libraries
       - web component sets
+    stars: 9
+    last_updated: "2019-09-10T13:04:10Z"
   - name: "`@sveltejs/svelte-virtual-list`"
-    url: https://github.com/sveltejs/svelte-virtual-list
+    url: "https://github.com/sveltejs/svelte-virtual-list"
     description: A virtual list component for Svelte apps
     tags:
       - components and libraries
       - layout and structure
+    stars: 139
+    last_updated: "2019-10-08T19:58:37Z"
   - name: "`@sveltejs/svelte-scroller`"
-    url: https://github.com/sveltejs/svelte-scroller
+    url: "https://github.com/sveltejs/svelte-scroller"
     description: A `<Scroller>` component for Svelte apps
     tags:
       - components and libraries
       - layout and structure
+    stars: 50
+    last_updated: "2019-10-05T16:38:14Z"
   - name: "`@sveltejs/svelte-subdivide`"
-    url: https://github.com/sveltejs/svelte-subdivide
-    description: A component for building Blender-style layouts in Svelte apps (**VERSION
+    url: "https://github.com/sveltejs/svelte-subdivide"
+    description: >-
+      A component for building Blender-style layouts in Svelte apps (**VERSION
       2**)
     tags:
       - components and libraries
       - layout and structure
+    stars: 54
+    last_updated: "2019-10-05T16:08:49Z"
   - name: "`svelte-grid`"
-    url: https://github.com/vaheqelyan/svelte-grid
-    description: A responsive, draggable and resizable grid layout, for Svelte
+    url: "https://github.com/vaheqelyan/svelte-grid"
+    description: "A responsive, draggable and resizable grid layout, for Svelte"
     tags:
       - components and libraries
       - layout and structure
+    stars: 95
+    last_updated: "2019-10-07T11:01:51Z"
   - name: "`svelte-sortable-list`"
-    url: https://github.com/brunomolteni/svelte-sortable-list
+    url: "https://github.com/brunomolteni/svelte-sortable-list"
     description: A list with animated drag-n-drop functionality
     tags:
       - components and libraries
       - layout and structure
+    stars: 9
+    last_updated: "2019-10-05T16:38:54Z"
   - name: "`@beyonk/svelte-carousel`"
-    url: https://github.com/beyonk-adventures/svelte-carousel
-    description: A super lightweight, super simple carousel for Svelte 3
+    url: "https://github.com/beyonk-adventures/svelte-carousel"
+    description: "A super lightweight, super simple carousel for Svelte 3"
     tags:
       - components and libraries
       - layout and structure
+    stars: 29
+    last_updated: "2019-10-10T20:00:13Z"
   - name: "`multicarousel`"
-    url: https://github.com/sciactive/multicarousel
+    url: "https://github.com/sciactive/multicarousel"
     description: A dependency free multiple item JavaScript carousel
     tags:
       - components and libraries
       - layout and structure
+    stars: 19
+    last_updated: "2019-08-21T21:56:57Z"
   - name: "`svelte-swipe`"
-    url: https://github.com/SharifClick/svelte-swipe
+    url: "https://github.com/SharifClick/svelte-swipe"
     description: A carousel with touch support
     tags:
       - components and libraries
       - layout and structure
+    stars: 8
+    last_updated: "2019-10-09T21:09:17Z"
   - name: "`svelte-tabs`"
-    url: https://github.com/joeattardi/svelte-tabs
+    url: "https://github.com/joeattardi/svelte-tabs"
     description: Tabs component for Svelte
     tags:
       - components and libraries
       - layout and structure
+    stars: 16
+    last_updated: "2019-10-05T16:41:47Z"
   - name: "`svelte-media-query`"
-    url: https://github.com/xelaok/svelte-media-query
+    url: "https://github.com/xelaok/svelte-media-query"
     description: CSS media queries in Svelte
     tags:
       - components and libraries
       - layout and structure
+    stars: 10
+    last_updated: "2019-09-08T12:30:41Z"
   - name: "`svelte-match-media`"
-    url: https://github.com/pearofducks/svelte-match-media
+    url: "https://github.com/pearofducks/svelte-match-media"
     description: a matchMedia plugin for Svelte 3
     tags:
       - components and libraries
       - layout and structure
+    stars: 4
+    last_updated: "2019-10-07T17:36:17Z"
   - name: "`svelte-watch-resize`"
-    url: https://github.com/xelaok/svelte-watch-resize
+    url: "https://github.com/xelaok/svelte-watch-resize"
     description: Watch element resize in Svelte
     tags:
       - components and libraries
       - layout and structure
+    stars: 3
+    last_updated: "2019-09-13T20:34:19Z"
   - name: "`svelte-simple-modal`"
-    url: https://github.com/flekschas/svelte-simple-modal
-    description: A simple, small, and content-agnostic modal for Svelte
+    url: "https://github.com/flekschas/svelte-simple-modal"
+    description: "A simple, small, and content-agnostic modal for Svelte"
     tags:
       - components and libraries
       - layout and structure
+    stars: 8
+    last_updated: "2019-10-03T14:19:30Z"
   - name: "`svelte-popover`"
-    url: https://github.com/vaheqelyan/svelte-popover
+    url: "https://github.com/vaheqelyan/svelte-popover"
     description: A smart popover component for Svelte
     tags:
       - components and libraries
       - layout and structure
+    stars: 11
+    last_updated: "2019-10-06T19:19:10Z"
   - name: "`svelte-headroom`"
-    url: https://github.com/collardeau/svelte-headroom
+    url: "https://github.com/collardeau/svelte-headroom"
     description: A Svelte component to hide your header on scroll
     tags:
       - components and libraries
       - layout and structure
+    stars: 6
+    last_updated: "2019-10-07T21:02:30Z"
   - name: "`@sveltejs/svelte-repl`"
-    url: https://github.com/sveltejs/svelte-repl
+    url: "https://github.com/sveltejs/svelte-repl"
     description: The `<Repl>` component used on the Svelte website
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 62
+    last_updated: "2019-10-10T19:59:46Z"
   - name: "`svelte-color-picker`"
-    url: https://github.com/qintarp/svelte-color-picker
+    url: "https://github.com/qintarp/svelte-color-picker"
     description: A color picker component for Svelte
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 17
+    last_updated: "2019-10-06T16:37:17Z"
   - name: "`svelte-select`"
-    url: https://github.com/rob-balfre/svelte-select
+    url: "https://github.com/rob-balfre/svelte-select"
     description: A select component for Svelte apps
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 89
+    last_updated: "2019-10-09T12:19:12Z"
   - name: "`svelte-rate-it`"
-    url: https://github.com/emrekara37/svelte-rate-it
+    url: "https://github.com/emrekara37/svelte-rate-it"
     description: A rate component for Svelte apps
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 16
+    last_updated: "2019-10-07T17:52:35Z"
   - name: "`waxwing-rating`"
-    url: https://github.com/dmitrykurmanov/waxwing-rating
+    url: "https://github.com/dmitrykurmanov/waxwing-rating"
     description: rating widget for the web
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 4
+    last_updated: "2019-09-09T00:42:20Z"
   - name: "`@beyonk/gdpr-cookie-consent-banner`"
-    url: https://github.com/beyonk-adventures/gdpr-cookie-consent-banner
+    url: "https://github.com/beyonk-adventures/gdpr-cookie-consent-banner"
     description: A GDPR compliant cookie consent banner implementation
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 7
+    last_updated: "2019-10-03T14:12:24Z"
   - name: "`svelte-inspect`"
-    url: https://github.com/trbrc/svelte-inspect
+    url: "https://github.com/trbrc/svelte-inspect"
     description: console.log()-like interactive inspector for Svelte 3
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 9
+    last_updated: "2019-10-03T14:10:41Z"
   - name: "`@okrad/svelte-progressbar`"
-    url: https://github.com/okrad/svelte-progressbar
-    description: A multiseries, SVG progressbar component made with Svelte
+    url: "https://github.com/okrad/svelte-progressbar"
+    description: "A multiseries, SVG progressbar component made with Svelte"
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 13
+    last_updated: "2019-10-03T14:10:48Z"
   - name: Browser REPL JS
-    url: https://github.com/milafrerichs/browser-repl-js
+    url: "https://github.com/milafrerichs/browser-repl-js"
     description: A Javascript REPL (code editor and code results) component
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 2
+    last_updated: "2019-09-20T12:23:05Z"
   - name: Simple Svelte Autocomplete
-    url: https://github.com/pstanoev/simple-svelte-autocomplete
+    url: "https://github.com/pstanoev/simple-svelte-autocomplete"
     description: Simple autocomplete / typeahead component for Svelte
     tags:
       - components and libraries
       - inputs and widgets
+    stars: 2
+    last_updated: "2019-10-02T14:23:18Z"
   - name: "`svelte-icons`"
-    url: https://github.com/gibdig/svelte-icons
-    description: Icon components for Svelte, featuring many icon sets
+    url: "https://github.com/gibdig/svelte-icons"
+    description: "Icon components for Svelte, featuring many icon sets"
     tags:
       - components and libraries
       - fonts and icons
+    stars: 8
+    last_updated: "2019-10-09T10:31:07Z"
   - name: "`svelte-awesome`"
-    url: https://github.com/RobBrazier/svelte-awesome
-    description: Awesome SVG icon component for Svelte JS, built with Font Awesome icons
+    url: "https://github.com/RobBrazier/svelte-awesome"
+    description: "Awesome SVG icon component for Svelte JS, built with Font Awesome icons"
     tags:
       - components and libraries
       - fonts and icons
+    stars: 65
+    last_updated: "2019-10-07T09:32:10Z"
   - name: "`svelte-fa`"
-    url: https://github.com/Cweili/svelte-fa
+    url: "https://github.com/Cweili/svelte-fa"
     description: Tiny FontAwesome 5 component for Svelte
     tags:
       - components and libraries
       - fonts and icons
+    stars: 14
+    last_updated: "2019-10-04T15:53:46Z"
   - name: "`fa-svelte`"
-    url: https://github.com/alphapeter/fa-svelte
+    url: "https://github.com/alphapeter/fa-svelte"
     description: Font Awesome 5 for Svelte
     tags:
       - components and libraries
       - fonts and icons
+    stars: 10
+    last_updated: "2019-10-08T21:06:32Z"
   - name: "`svelte-feather-icons`"
-    url: https://github.com/dylanblokhuis/svelte-feather-icons
+    url: "https://github.com/dylanblokhuis/svelte-feather-icons"
     description: Feather icons for Svelte
     tags:
       - components and libraries
       - fonts and icons
+    stars: 13
+    last_updated: "2019-08-26T04:48:28Z"
   - name: "`@spaceavocado/svelte-form`"
-    url: https://github.com/spaceavocado/svelte-form
+    url: "https://github.com/spaceavocado/svelte-form"
     description: Simple Svelte form model handler and input validations
     tags:
       - components and libraries
       - forms and validation
+    stars: 5
+    last_updated: "2019-10-03T14:07:45Z"
   - name: "`svelte-forms`"
-    url: https://github.com/chainlist/svelte-forms
+    url: "https://github.com/chainlist/svelte-forms"
     description: Svelte forms validation made easy
     tags:
       - components and libraries
       - forms and validation
+    stars: 17
+    last_updated: "2019-10-03T14:07:01Z"
   - name: "`svelte-forms-lib`"
-    url: https://github.com/tjinauyeung/svelte-forms-lib
+    url: "https://github.com/tjinauyeung/svelte-forms-lib"
     description: A lightweight library for managing forms in Svelte
     tags:
       - components and libraries
       - forms and validation
+    stars: 12
+    last_updated: "2019-10-06T01:46:15Z"
   - name: "`sveltejs-forms`"
-    url: https://github.com/mdauner/sveltejs-forms
+    url: "https://github.com/mdauner/sveltejs-forms"
     description: Form components using Yup for validation
     tags:
       - components and libraries
       - forms and validation
+    stars: 11
+    last_updated: "2019-10-11T03:56:00Z"
   - name: "`svelte-waypoint`"
-    url: https://github.com/matyunya/svelte-waypoint
+    url: "https://github.com/matyunya/svelte-waypoint"
     description: Lazyload images or anything component for Svelte
     tags:
       - components and libraries
       - images
+    stars: 17
+    last_updated: "2019-09-16T14:00:58Z"
   - name: "`svelte-image`"
-    url: https://github.com/matyunya/svelte-image
+    url: "https://github.com/matyunya/svelte-image"
     description: Image processing with Sharp for Svelte
     tags:
       - components and libraries
       - images
+    stars: 62
+    last_updated: "2019-10-06T12:56:47Z"
   - name: "`svelte-image-encoder`"
-    url: https://github.com/saabi/svelte-image-encoder
+    url: "https://github.com/saabi/svelte-image-encoder"
     description: An `<ImgEncoder>` component for editing and compressing profile pictures
     tags:
       - components and libraries
       - images
+    stars: 13
+    last_updated: "2019-10-05T16:04:33Z"
   - name: "`svelte-easy-crop`"
-    url: https://github.com/ValentinH/svelte-easy-crop
+    url: "https://github.com/ValentinH/svelte-easy-crop"
     description: A Svelte component to crop images with easy interactions
     tags:
       - components and libraries
       - images
+    stars: 24
+    last_updated: "2019-10-10T21:29:28Z"
   - name: "`echarts-for-svelte`"
-    url: https://github.com/liyuanqiu/echarts-for-svelte
+    url: "https://github.com/liyuanqiu/echarts-for-svelte"
     description: Baidu Echarts(v3.0 & v4.0) components for Svelte wrapper
     tags:
       - components and libraries
       - charts
+    stars: 8
+    last_updated: "2019-09-13T20:51:22Z"
   - name: "`svelte-fusioncharts`"
-    url: https://github.com/priyanjitdey94/svelte-fusioncharts
+    url: "https://github.com/priyanjitdey94/svelte-fusioncharts"
     description: Svelte component for FusionCharts JavaScript charting library
     tags:
       - components and libraries
       - charts
+    stars: 17
+    last_updated: "2019-09-25T11:31:43Z"
   - name: "`svelte-calendar`"
-    url: https://github.com/6eDesign/svelte-calendar
+    url: "https://github.com/6eDesign/svelte-calendar"
     description: A lightweight datepicker with neat animations and a unique UX
     tags:
       - components and libraries
       - time and date
+    stars: 50
+    last_updated: "2019-10-10T18:19:43Z"
   - name: "`svelte-flatpickr`"
-    url: https://github.com/jacobmischka/svelte-flatpickr
+    url: "https://github.com/jacobmischka/svelte-flatpickr"
     description: Flatpickr component for Svelte
     tags:
       - components and libraries
       - time and date
+    stars: 11
+    last_updated: "2019-10-10T07:39:30Z"
   - name: "`@beyonk/svelte-notifications`"
-    url: https://github.com/beyonk-adventures/svelte-notifications
+    url: "https://github.com/beyonk-adventures/svelte-notifications"
     description: Svelte toast notifications that can be used in any JS application
     tags:
       - components and libraries
       - notifications
+    stars: 28
+    last_updated: "2019-10-10T15:34:30Z"
   - name: "`svelte-notifications`"
-    url: https://github.com/keenethics/svelte-notifications
+    url: "https://github.com/keenethics/svelte-notifications"
     description: Simple and flexible notifications system
     tags:
       - components and libraries
       - notifications
+    stars: 64
+    last_updated: "2019-10-09T17:41:36Z"
   - name: "`@beyonk/svelte-mapbox`"
-    url: https://github.com/beyonk-adventures/svelte-mapbox
+    url: "https://github.com/beyonk-adventures/svelte-mapbox"
     description: Mapbox integration for Svelte
     tags:
       - components and libraries
       - maps
+    stars: 11
+    last_updated: "2019-10-09T19:10:54Z"
   - name: "`@beyonk/svelte-googlemaps`"
-    url: https://github.com/beyonk-adventures/svelte-googlemaps
+    url: "https://github.com/beyonk-adventures/svelte-googlemaps"
     description: Google Maps integration for Svelte
     tags:
       - components and libraries
       - maps
+    stars: 7
+    last_updated: "2019-09-23T15:47:57Z"
   - name: "`svelte-pick-a-place`"
-    url: https://github.com/jimutt/svelte-pick-a-place
+    url: "https://github.com/jimutt/svelte-pick-a-place"
     description: Svelte component for position and area selection with Leaflet
     tags:
       - components and libraries
       - maps
+    stars: 20
+    last_updated: "2019-09-30T18:27:19Z"
   - name: "`svelte-i18n`"
-    url: https://github.com/kaisermann/svelte-i18n
+    url: "https://github.com/kaisermann/svelte-i18n"
     description: Internationalization library for Svelte
     tags:
       - components and libraries
       - internationalization
+    stars: 91
+    last_updated: "2019-10-10T12:43:02Z"
   - name: "`svelte-intl`"
-    url: https://github.com/Panya/svelte-intl
+    url: "https://github.com/Panya/svelte-intl"
     description: Internationalize your Svelte apps using format-message and Intl object
     tags:
       - components and libraries
       - internationalization
+    stars: 15
+    last_updated: "2019-10-09T02:09:39Z"
   - name: "`svelte-writable-derived`"
-    url: https://github.com/PikadudeNo1/svelte-writable-derived
+    url: "https://github.com/PikadudeNo1/svelte-writable-derived"
     description: Two-way data-transforming stores
     tags:
       - components and libraries
       - stores and state
+    stars: 8
+    last_updated: "2019-10-09T18:11:44Z"
   - name: "`svelte-apollo`"
-    url: https://github.com/timhall/svelte-apollo
+    url: "https://github.com/timhall/svelte-apollo"
     description: Svelte integration for Apollo GraphQL
     tags:
       - components and libraries
       - stores and state
+    stars: 221
+    last_updated: "2019-10-08T11:33:14Z"
   - name: Svelte for Meteor
-    url: https://github.com/meteor-svelte/meteor-svelte
+    url: "https://github.com/meteor-svelte/meteor-svelte"
     description: Build cybernetically enhanced web apps with Meteor and Svelte
     tags:
       - components and libraries
       - stores and state
+    stars: 45
+    last_updated: "2019-10-05T10:29:35Z"
   - name: "`svelte-webext-storage-adapter`"
-    url: https://github.com/PikadudeNo1/svelte-webext-storage-adapter
+    url: "https://github.com/PikadudeNo1/svelte-webext-storage-adapter"
     description: Writable stores for Firefox/Chrome extensions using `chrome.storage`
     tags:
       - components and libraries
       - stores and state
+    stars: 3
+    last_updated: "2019-07-24T18:42:12Z"
   - name: "`svelte-observable`"
-    url: https://github.com/timhall/svelte-observable
+    url: "https://github.com/timhall/svelte-observable"
     description: Use observables in Svelte components with ease
     tags:
       - components and libraries
       - stores and state
+    stars: 15
+    last_updated: "2019-09-24T07:16:15Z"
   - name: "`svelte-mobx`"
-    url: https://github.com/xelaok/svelte-mobx
+    url: "https://github.com/xelaok/svelte-mobx"
     description: Reactive MVVM with MobX & Svelte
     tags:
       - components and libraries
       - stores and state
+    stars: 6
+    last_updated: "2019-09-23T13:08:17Z"
   - name: "`svelte-redux-connect`"
-    url: https://github.com/kolodziejczak-sz/svelte-redux-connect
+    url: "https://github.com/kolodziejczak-sz/svelte-redux-connect"
     description: Redux binding to Svelte based on react-redux
     tags:
       - components and libraries
       - stores and state
+    stars: 2
+    last_updated: "2019-10-07T17:24:03Z"
   - name: "`svql`"
-    url: https://github.com/pateketrueke/svql
-    description: Wrapper for FetchQL, a GraphQL query client
+    url: "https://github.com/pateketrueke/svql"
+    description: "Wrapper for FetchQL, a GraphQL query client"
     tags:
       - components and libraries
       - stores and state
+    stars: 4
+    last_updated: "2019-09-30T13:16:19Z"
   - name: "`@sveltejs/gestures`"
-    url: https://github.com/sveltejs/gestures
+    url: "https://github.com/sveltejs/gestures"
     description: Svelte actions for cross-platform gesture detection (work in progress)
     tags:
       - components and libraries
       - interaction
+    stars: 35
+    last_updated: "2019-10-05T16:09:50Z"
   - name: "`@beyonk/svelte-scrollspy`"
-    url: https://github.com/beyonk-adventures/svelte-scrollspy
+    url: "https://github.com/beyonk-adventures/svelte-scrollspy"
     description: Scroll Spy component for Svelte
     tags:
       - components and libraries
       - interaction
+    stars: 8
+    last_updated: "2019-09-30T12:35:00Z"
   - name: "`svelte-loadable`"
-    url: https://github.com/kaisermann/svelte-loadable
+    url: "https://github.com/kaisermann/svelte-loadable"
     description: Dynamically load a Svelte component
     tags:
       - components and libraries
       - async loading
+    stars: 57
+    last_updated: "2019-10-10T19:28:59Z"
   - name: "`svelte-content-loader`"
-    url: https://github.com/PaulMaly/svelte-content-loader
+    url: "https://github.com/PaulMaly/svelte-content-loader"
     description: SVG placeholder components for loading content
     tags:
       - components and libraries
       - async loading
+    stars: 32
+    last_updated: "2019-10-07T14:11:29Z"
   - name: "`@beyonk/svelte-google-analytics`"
-    url: https://github.com/beyonk-adventures/svelte-google-analytics
+    url: "https://github.com/beyonk-adventures/svelte-google-analytics"
     description: Google Analytics tracking module for Svelte / Sapper
     tags:
       - components and libraries
       - social and other 3rd party services
+    stars: 0
+    last_updated: "2019-02-25T11:48:37Z"
   - name: "`@beyonk/svelte-facebook-pixel`"
-    url: https://github.com/beyonk-adventures/svelte-facebook-pixel
+    url: "https://github.com/beyonk-adventures/svelte-facebook-pixel"
     description: A Facebook pixel module for Svelte / Sapper
     tags:
       - components and libraries
       - social and other 3rd party services
+    stars: 1
+    last_updated: "2019-07-04T08:01:22Z"
   - name: "`@beyonk/svelte-facebook-customer-chat`"
-    url: https://github.com/beyonk-adventures/svelte-facebook-customer-chat
+    url: "https://github.com/beyonk-adventures/svelte-facebook-customer-chat"
     description: A Facebook customer chat integration for Svelte / Sapper
     tags:
       - components and libraries
       - social and other 3rd party services
+    stars: 0
+    last_updated: "2019-05-25T17:04:08Z"
   - name: "`@beyonk/svelte-trustpilot`"
-    url: https://github.com/beyonk-adventures/svelte-trustpilot
+    url: "https://github.com/beyonk-adventures/svelte-trustpilot"
     description: Trustpilot Trustboxes for Svelte / Sapper
     tags:
       - components and libraries
       - social and other 3rd party services
+    stars: 0
+    last_updated: "2019-06-22T07:12:28Z"
   - name: Svelte DevTools
-    url: https://github.com/RedHatter/svelte-devtools
-    description: Chrome/Firefox extension that allows inspection of Svelte components and
+    url: "https://github.com/RedHatter/svelte-devtools"
+    description: >-
+      Chrome/Firefox extension that allows inspection of Svelte components and
       state
     tags:
       - components and libraries
       - development and documentation
+    stars: 165
+    last_updated: "2019-10-10T01:42:16Z"
   - name: "`sveltedoc-parser`"
-    url: https://github.com/alexprey/sveltedoc-parser
+    url: "https://github.com/alexprey/sveltedoc-parser"
     description: Generate a JSON documentation for a Svelte component
     tags:
       - components and libraries
       - development and documentation
+    stars: 16
+    last_updated: "2019-10-02T15:04:58Z"
   - name: "`prettier-plugin-svelte`"
-    url: https://github.com/UnwrittenFun/prettier-plugin-svelte
+    url: "https://github.com/UnwrittenFun/prettier-plugin-svelte"
     description: Format your Svelte components using Prettier
     tags:
       - components and libraries
       - development and documentation
+    stars: 85
+    last_updated: "2019-10-05T17:07:16Z"
   - name: "`svelte-inspector`"
-    url: https://github.com/qutran/svelte-inspector
-    description: Development helper for inspecting and opening Svelte components in your
+    url: "https://github.com/qutran/svelte-inspector"
+    description: >-
+      Development helper for inspecting and opening Svelte components in your
       editor
     tags:
       - components and libraries
       - development and documentation
+    stars: 33
+    last_updated: "2019-10-01T13:06:19Z"
   - name: "`svelte-dev-helper`"
-    url: https://github.com/ekhaled/svelte-dev-helper
+    url: "https://github.com/ekhaled/svelte-dev-helper"
     description: Helper for Svelte components to ease development. Used by `svelte-loader`
     tags:
       - components and libraries
       - development and documentation
+    stars: 6
+    last_updated: "2019-09-23T14:13:02Z"
   - name: "`svelte-adapter`"
-    url: https://github.com/pngwn/svelte-adapter
+    url: "https://github.com/pngwn/svelte-adapter"
     description: Use Svelte components with Vue and React
     tags:
       - components and libraries
       - other components and libraries
+    stars: 91
+    last_updated: "2019-10-10T19:14:00Z"
   - name: "`svelte-css-vars`"
-    url: https://github.com/kaisermann/svelte-css-vars
-    description: Ever wanted to have reactive css variables in Svelte? What if I tell you
+    url: "https://github.com/kaisermann/svelte-css-vars"
+    description: >-
+      Ever wanted to have reactive css variables in Svelte? What if I tell you
       there's a way?
     tags:
       - components and libraries
       - other components and libraries
+    stars: 24
+    last_updated: "2019-10-10T19:09:59Z"
   - name: svelte-native
-    url: https://github.com/halfnelson/svelte-native
+    url: "https://github.com/halfnelson/svelte-native"
     description: Svelte controlling native components via Nativescript
     tags:
       - native
+    stars: 285
+    last_updated: "2019-10-11T01:58:00Z"
   - name: "`@sveltejs/gl`"
-    url: https://github.com/sveltejs/gl
+    url: "https://github.com/sveltejs/gl"
     description: A (very experimental) project to bring WebGL to Svelte
     tags:
       - experiments
+    stars: 163
+    last_updated: "2019-10-10T13:19:16Z"
   - name: Svelte TodoMVC
-    url: https://github.com/sveltejs/svelte-todomvc
-    description: TodoMVC implemented in Svelte (<https://svelte-todomvc.surge.sh>)
+    url: "https://github.com/sveltejs/svelte-todomvc"
+    description: "TodoMVC implemented in Svelte (<https://svelte-todomvc.surge.sh>)"
     tags:
       - example app showcase
+    stars: 83
+    last_updated: "2019-09-24T04:43:30Z"
   - name: RealWorld example app
-    url: https://github.com/sveltejs/realworld
-    description: Svelte/Sapper implementation of the RealWorld app
+    url: "https://github.com/sveltejs/realworld"
+    description: >-
+      Svelte/Sapper implementation of the RealWorld app
       (<https://svelte-realworld.now.sh>)
     tags:
       - example app showcase
+    stars: 356
+    last_updated: "2019-10-10T21:28:51Z"
   - name: Svelte REPL
-    url: https://github.com/sveltejs/svelte-repl
-    description: The `<Repl>` component used on the Svelte website
+    url: "https://github.com/sveltejs/svelte-repl"
+    description: >-
+      The `<Repl>` component used on the Svelte website
       (<https://svelte.dev/repl>)
     tags:
       - example app showcase
+    stars: 62
+    last_updated: "2019-10-10T19:59:46Z"
   - name: Svelte DBMonster
-    url: https://github.com/sveltejs/svelte-dbmonster
-    description: Svelte implementation of DBMonster (<http://svelte-dbmonster.surge.sh>)
+    url: "https://github.com/sveltejs/svelte-dbmonster"
+    description: >-
+      Svelte implementation of DBMonster (<http://svelte-dbmonster.surge.sh>)
       (**VERSION 2**)
     tags:
       - example app showcase
+    stars: 11
+    last_updated: "2019-06-30T20:24:44Z"
   - name: hn.svelte.dev
-    url: https://github.com/sveltejs/hn.svelte.dev
-    description: Hacker News clone built with Svelte and Sapper (<https://hn.svelte.dev>)
+    url: "https://github.com/sveltejs/hn.svelte.dev"
+    description: "Hacker News clone built with Svelte and Sapper (<https://hn.svelte.dev>)"
     tags:
       - example app showcase
+    stars: 46
+    last_updated: "2019-10-10T00:20:42Z"
   - name: svelte-travel-transitions
-    url: https://github.com/pngwn/svelte-travel-transitions
-    description: Native-like Page Transitions with Svelte and Sapper, A Travel App
+    url: "https://github.com/pngwn/svelte-travel-transitions"
+    description: "Native-like Page Transitions with Svelte and Sapper, A Travel App"
     tags:
       - example app showcase
+    stars: 62
+    last_updated: "2019-10-11T06:38:28Z"
   - name: New Tab
-    url: https://github.com/MaxMilton/new-tab
-    description: ⚡ A high performance Google Chrome new tab page that gets you where you
+    url: "https://github.com/MaxMilton/new-tab"
+    description: >-
+      ⚡ A high performance Google Chrome new tab page that gets you where you
       need to go faster
     tags:
       - example app showcase
+    stars: 22
+    last_updated: "2019-10-05T08:45:00Z"
   - name: NAU Tab
-    url: https://github.com/trongthanh/nau-chrome-tab
-    description: Beautiful New Tab extension for Chrome, Firefox and browsers support web
+    url: "https://github.com/trongthanh/nau-chrome-tab"
+    description: >-
+      Beautiful New Tab extension for Chrome, Firefox and browsers support web
       extension
     tags:
       - example app showcase
+    stars: 18
+    last_updated: "2019-09-29T21:49:08Z"
   - name: Perfect Home
-    url: https://github.com/tborychowski/perfect-home
+    url: "https://github.com/tborychowski/perfect-home"
     description: Firefox newtab/home replacement
     tags:
       - example app showcase
+    stars: 4
+    last_updated: "2019-10-09T15:50:52Z"
   - name: Nomie
-    url: https://github.com/open-nomie/nomie
+    url: "https://github.com/open-nomie/nomie"
     description: Mood and Life Tracker built with Svelte
     tags:
       - example app showcase
+    stars: 117
+    last_updated: "2019-10-10T02:56:09Z"
   - name: palettes
-    url: https://github.com/gka/palettes
-    description: A tool for creating nice, percerptually correct and colorblind-safe color
+    url: "https://github.com/gka/palettes"
+    description: >-
+      A tool for creating nice, percerptually correct and colorblind-safe color
       palettes
     tags:
       - example app showcase
+    stars: 82
+    last_updated: "2019-10-10T06:26:30Z"
   - name: Svelte's official blog
-    url: https://svelte.dev/blog
+    url: "https://svelte.dev/blog"
     tags:
       - media
   - name: "@sveltejs on Twitter"
-    url: https://twitter.com/sveltejs
+    url: "https://twitter.com/sveltejs"
     tags:
       - media
   - name: Rich Harris - Rethinking reactivity - YGLF 2019
-    url: https://www.youtube.com/watch?v=AdNJ3fydeao
+    url: "https://www.youtube.com/watch?v=AdNJ3fydeao"
     tags:
       - media
       - talks
-  - name: Rich Harris - Computer, build me an app - JSConf EU 2018
-    url: https://www.youtube.com/watch?v=qqt6YxAZoOc
+  - name: "Rich Harris - Computer, build me an app - JSConf EU 2018"
+    url: "https://www.youtube.com/watch?v=qqt6YxAZoOc"
     tags:
       - media
       - talks
   - name: "Shop Talk #349 - Talking Svelte with Rich Harris"
-    url: https://shoptalkshow.com/episodes/349/
+    url: "https://shoptalkshow.com/episodes/349/"
     tags:
       - media
       - podcasts and other videos
   - name: "devmode.fm #44 - Svelte 3’s radical new approach to web frameworks"
-    url: https://devmode.fm/episodes/svelte-3s-radical-new-approach-to-web-frameworks
+    url: >-
+      https://devmode.fm/episodes/svelte-3s-radical-new-approach-to-web-frameworks
     tags:
       - media
       - podcasts and other videos
-  - name: "The Undefined Podcast #8 - Fake News and Frameworks with NYTimes Rich
-      Harris"
-    url: https://undefined.fm/radio/fake-news-and-frameworks-with-nytimes-rich-harris/
+  - name: >-
+      The Undefined Podcast #8 - Fake News and Frameworks with NYTimes Rich
+      Harris
+    url: >-
+      https://undefined.fm/radio/fake-news-and-frameworks-with-nytimes-rich-harris/
     tags:
       - media
       - podcasts and other videos
   - name: "Toolsday #93 - Svelte"
-    url: https://spec.fm/podcasts/toolsday/293076
+    url: "https://spec.fm/podcasts/toolsday/293076"
     tags:
       - media
       - podcasts and other videos
   - name: Harry Wolff - A Svelte Chat with Rich Harris!
-    url: https://www.youtube.com/watch?v=48gHuY4w0hY
+    url: "https://www.youtube.com/watch?v=48gHuY4w0hY"
     tags:
       - media
       - podcasts and other videos
   - name: The Frontside Podcast - Svelte and Reactivity with Rich Harris
-    url: https://frontside.io/podcast/svelte-and-reactivity-with-rich-harris/
+    url: "https://frontside.io/podcast/svelte-and-reactivity-with-rich-harris/"
     tags:
       - media
       - podcasts and other videos
   - name: egghead.io - Svelte 3 with Rich Harris
-    url: https://egghead.io/lessons/egghead-svelte-3-with-rich-harris
+    url: "https://egghead.io/lessons/egghead-svelte-3-with-rich-harris"
     tags:
       - media
       - podcasts and other videos
   - name: awesome-svelte
-    url: https://github.com/CalvinWalzel/awesome-svelte
+    url: "https://github.com/CalvinWalzel/awesome-svelte"
     description: A curated list of awesome things related to Svelte (includes v2 resources)
     tags:
       - other lists and resources
+    stars: 270
+    last_updated: "2019-10-10T22:01:58Z"
   - name: svelte-sapper-community
-    url: https://github.com/mindrones/svelte-sapper-community
+    url: "https://github.com/mindrones/svelte-sapper-community"
     description: Svelte/Sapper community map
     tags:
       - other lists and resources
+    stars: 4
+    last_updated: "2019-07-10T07:28:13Z"
   - name: Why Svelte
-    url: https://why-svelte-js.web.app/
-    description: A collection of blog posts, videos, and other Svelte resources
+    url: "https://why-svelte-js.web.app/"
+    description: "A collection of blog posts, videos, and other Svelte resources"
     tags:
       - other lists and resources
   - name: Svelte Status
-    url: http://www.sveltestatus.com/
+    url: "http://www.sveltestatus.com/"
     description: Weekly curated blogs and tools for Svelte developers
     tags:
       - other lists and resources

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
   "dependencies": {
     "@ssgjs/source-yaml": "^0.0.3",
     "@sveltejs/site-kit": "^1.1.4",
+    "dotenv": "^8.1.0",
     "fuse.js": "^3.4.5",
+    "js-yaml": "^3.13.1",
+    "node-fetch": "^2.6.0",
     "ssg": "^0.0.38",
     "yaml": "^1.7.1"
   },
   "scripts": {
     "start": "ssg dev",
-    "build": "ssg export"
+    "build": "ssg export",
+    "update": "node scripts/updateResources.js"
   }
 }

--- a/scripts/updateResources.js
+++ b/scripts/updateResources.js
@@ -1,0 +1,64 @@
+// Used to fetch and update number of stars on each resource.
+require("dotenv").config();
+const fs = require("fs");
+const yaml = require("js-yaml");
+const fetch = require("node-fetch");
+
+async function getStars() {
+  try {
+    const resources = yaml.safeLoad(
+      fs.readFileSync("data/resources.yml", "utf8")
+    );
+
+    const updatedResources = await Promise.all(
+      resources.resources.map(async res => {
+        // if (hasGitHubUrl) {
+        let result = await fetch(
+          `https://api.github.com/repos/jasonrudolph/keyboard?client_id=${process.env.GITHUB_CLIENT_ID}&client_secret=${process.env.GITHUB_CLIENT_SECRET}`
+        );
+
+        result = await result.json();
+
+        return {
+          ...res,
+          stars: result.watchers,
+          last_updated: result.updated_at
+        };
+        // } else {
+        //   return res;
+        // }
+      })
+    );
+
+    const finishedYaml = {
+      ...resources,
+      resources: updatedResources
+    };
+
+    fs.writeFile("data/resources.yml", yaml.safeDump(finishedYaml), err => {
+      if (err) {
+        console.log(err);
+      }
+    });
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+getStars();
+
+// const url = "https://api.github.com/repos/";
+
+// async function main() {
+//   const starships = [];
+
+//   const res = await fetch(base, opts);
+//   const list = await res.json();
+
+//   fs.writeFileSync(
+//     `../src/routes/_starships.js`,
+//     `export default ${JSON.stringify(list)};`
+//   );
+// }
+
+// main();

--- a/scripts/updateResources.js
+++ b/scripts/updateResources.js
@@ -57,19 +57,3 @@ async function getStars() {
 }
 
 getStars();
-
-// const url = "https://api.github.com/repos/";
-
-// async function main() {
-//   const starships = [];
-
-//   const res = await fetch(base, opts);
-//   const list = await res.json();
-
-//   fs.writeFileSync(
-//     `../src/routes/_starships.js`,
-//     `export default ${JSON.stringify(list)};`
-//   );
-// }
-
-// main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,6 +393,11 @@ debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
+dotenv@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
+  integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -757,6 +762,11 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds a rudimentary script to fetch number of stars as well as last_updated attribute on all the resources that contain "github.com" in it's URL. 

The url for these github resources should be in the following format to work: "https://github.com/organization/repo"

Adds these environment variables:
GITHUB_CLIENT_ID
GITHUB_CLIENT_SECRET