### PR TITLE
remove list item style from code and resource items

### DIFF
--- a/src/routes/code.svelte
+++ b/src/routes/code.svelte
@@ -82,6 +82,7 @@
   }
   .resource {
     margin-bottom: 1em;
+    list-style: none;
   }
   input {
     font-family: inherit;

--- a/src/routes/resources.svelte
+++ b/src/routes/resources.svelte
@@ -82,6 +82,7 @@
   }
   .resource {
     margin-bottom: 1em;
+    list-style: none;
   }
   input {
     font-family: inherit;


### PR DESCRIPTION
This is a tiny styling tweak that was irking me since the first styling pass I did. It just removes the bullet points. Might want more whitespace between items.
![pic1](https://user-images.githubusercontent.com/2608646/68259072-71f26d80-fffe-11e9-971d-5ebe607f21a2.png)
after:
![pic2](https://user-images.githubusercontent.com/2608646/68259076-7454c780-fffe-11e9-91ad-a8247a48e430.png)

