### PR TITLE
Fix URL because the previous one leads to a 404.

### DIFF
--- a/whos-using-svelte/WhosUsingSvelte.svelte
+++ b/whos-using-svelte/WhosUsingSvelte.svelte
@@ -101,6 +101,6 @@
 	<a target="_blank" rel="noopener" href="https://m.tokopedia.com"><img src="organisations/tokopedia.svg" alt="Tokopedia logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://webdesq.net"><img src="organisations/webdesq.svg" alt="Webdesq logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://zevvle.com/"><img src="organisations/zevvle.svg" alt="Zevvle logo" loading="lazy"></a>
-	<a target="_blank" rel="noopener" href="software-salary-calculator.netlify.com"><img src="organisations/swissdev-javascript-jobs.png" alt="SwissDev JavaScript Jobs" loading="lazy"></a>
+	<a target="_blank" rel="noopener" href="https://swissdevjobs.ch/jobs/JavaScript/All"><img src="organisations/swissdev-javascript-jobs.png" alt="SwissDev JavaScript Jobs" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://github.com/sveltejs/community/blob/master/whos-using-svelte/WhosUsingSvelte.svelte" class="add-yourself"><span>+ your company?</span></a>
 </div>


### PR DESCRIPTION
Fixed the URL to the correct one (where the Svelte component will be embedded).
The previous one was leading to a 404 not found page.