### PR TITLE
style the clear tags button differently

### DIFF
--- a/src/node_modules/components/ClearTagsButton.svelte
+++ b/src/node_modules/components/ClearTagsButton.svelte
@@ -1,0 +1,25 @@
+<script>
+  export let text = "🞩 clear selected tags";
+  export let clear;
+</script>
+
+<style>
+  /* TODO style this properly, particularly the colors */
+  .tag {
+    padding: 0.2em 0.4em;
+    margin-right: 0.8em;
+    margin-bottom: 0.4em;
+    background-color: rgba(21, 151, 148, 0.07);
+    border: 1px solid transparent;
+    cursor: pointer;
+    line-height: 1.2;
+  }
+  .tag:hover {
+    border-color: rgb(26, 197, 194);
+  }
+  .tag:active {
+    border-color: rgb(18, 138, 136);
+  }
+</style>
+
+<code class="tag" on:click={() => clear()}>{text}</code>

--- a/src/routes/code.svelte
+++ b/src/routes/code.svelte
@@ -13,6 +13,7 @@
   import Resource from "components/Resource.svelte";
   import TwoColumns from "components/TwoColumns.svelte";
   import Tag from "components/Tag.svelte";
+  import ClearTagsButton from "components/ClearTagsButton.svelte";
   import { transformResourceData } from "resources/transformResourceData.js";
   import { filterResourcesByTags } from "resources/helpers.js";
   import { createQueryParamSet } from "location/queryParams.js";
@@ -138,8 +139,7 @@
           toggle={selectedTags.toggle} />
       {/each}
       {#if $selectedTags.size}
-        <!-- TODO this should be styled distinctly, maybe just a different color, or removed if the UX changes -->
-        <Tag name="🞩 clear selected tags" toggle={selectedTags.clear} />
+        <ClearTagsButton clear={selectedTags.clear} />
       {/if}
     </div>
   </div>

--- a/src/routes/resources.svelte
+++ b/src/routes/resources.svelte
@@ -13,7 +13,8 @@
   import Box from "components/Box.svelte";
   import Resource from "components/Resource.svelte";
   import Tag from "components/Tag.svelte";
-  import TwoColumns from 'components/TwoColumns.svelte';
+  import ClearTagsButton from "components/ClearTagsButton.svelte";
+  import TwoColumns from "components/TwoColumns.svelte";
   import { transformResourceData } from "resources/transformResourceData.js";
   import { filterResourcesByTags } from "resources/helpers.js";
   import { createQueryParamSet } from "location/queryParams.js";
@@ -138,8 +139,7 @@
           toggle={selectedTags.toggle} />
       {/each}
       {#if $selectedTags.size}
-        <!-- TODO this should be styled distinctly, maybe just a different color, or removed if the UX changes -->
-        <Tag name="🞩 clear selected tags" toggle={selectedTags.clear} />
+        <ClearTagsButton clear={selectedTags.clear} />
       {/if}
     </div>
   </div>


### PR DESCRIPTION
This styles the "clear selected tags" button. Previously it looked the same as the other tags. Colors are hardcoded like elsewhere, and could be improved with app-wide style vars in a future PR.

old:

![old](https://user-images.githubusercontent.com/2608646/76169237-208cf300-6144-11ea-85d7-d03a18731f2f.jpg)

new:

![new](https://user-images.githubusercontent.com/2608646/76169216-f89d8f80-6143-11ea-940d-90579e49fb5e.jpg)
