### PR TITLE
fix resource layout

### DIFF
--- a/src/node_modules/components/Resource.svelte
+++ b/src/node_modules/components/Resource.svelte
@@ -57,14 +57,14 @@
       </a>
     </small>
   {/if}
-  {#if resource.stars || resource.last_updated}
-    <small class="scrapedMetadata">
-      {#if resource.last_updated}
-        <span>updated {timeSince(new Date(resource.last_updated))} ago</span>
-      {/if}
-      {#if resource.stars}
-        <span>{resource.stars} ⭐</span>
-      {/if}
-    </small>
-  {/if}
 </div>
+{#if resource.stars || resource.last_updated}
+  <small class="scrapedMetadata">
+    {#if resource.last_updated}
+      <span>updated {timeSince(new Date(resource.last_updated))} ago</span>
+    {/if}
+    {#if resource.stars}
+      <span>{resource.stars} ⭐</span>
+    {/if}
+  </small>
+{/if}


### PR DESCRIPTION
Fixes a recent regression.

before:
![sv1](https://user-images.githubusercontent.com/2608646/76439176-ffb5df00-6389-11ea-9670-cdcbb29c6ed4.png)

after:
![sv2](https://user-images.githubusercontent.com/2608646/76439195-080e1a00-638a-11ea-8bd6-7031d1d5418c.png)


