### PR TITLE
clean up tags for svelte-typewriter

### DIFF
--- a/data/code.yml
+++ b/data/code.yml
@@ -3,8 +3,7 @@ resources:
     url: 'https://github.com/henriquehbr/svelte-typewriter'
     description: A simple and reusable typewriter effect for your Svelte applications
     tags:
-      - svelte
-      - typewriter-effect
+      - components and libraries
     stars: 28
     downloads: 422
     last_updated: '2020-02-12T04:57:03Z'


### PR DESCRIPTION
The tags for `svelte-typewriter` were `"svelte"` and `"typewriter-effect"`, the first of which was unique and unnecessary, and the second of which is formatted uniquely and probably too specific. What tags _should_ it have though? The tag `"inputs and widgets"` probably isn't good, and `"layout and structure"` doesn't seem quite right but it might be the closest. Maybe we need a new tag? Maybe `"visual effects"` or `"animation"`?