### PR TITLE
broken link (certificate) for sveltestatus (fixes #138)

### DIFF
--- a/data/resources.yml
+++ b/data/resources.yml
@@ -178,11 +178,6 @@ resources:
     description: 'A collection of blog posts, videos, and other Svelte resources'
     tags:
       - other lists and resources
-  - name: Svelte Status
-    url: 'http://www.sveltestatus.com/'
-    description: Weekly curated blogs and tools for Svelte developers
-    tags:
-      - other lists and resources
   - name: Svelte news&links newsletter
     url: 'https://shershen08.github.io/sveltejsnews/'
     description: >-


### PR DESCRIPTION
fixes #138: "sveltestatus.com" is currently not maintained