### PR TITLE
display last_updated text in full days

### DIFF
--- a/src/node_modules/components/Resource.svelte
+++ b/src/node_modules/components/Resource.svelte
@@ -4,6 +4,15 @@
   export let selectedTags;
   export let toggleTag;
   import { timeSince } from "resources/helpers.js";
+
+  const getUpdatedText = resource => {
+    const text = timeSince(new Date(resource.last_updated));
+    if (text.indexOf("today") === -1 && text.indexOf("yesterday") === -1) {
+      return text + " ago";
+    } else {
+      return text;
+    }
+  };
 </script>
 
 <style>
@@ -61,7 +70,7 @@
 {#if resource.stars || resource.last_updated}
   <small class="scrapedMetadata">
     {#if resource.last_updated}
-      <span>updated {timeSince(new Date(resource.last_updated))} ago</span>
+      <span>updated {getUpdatedText(resource)}</span>
     {/if}
     {#if resource.stars}
       <span>{resource.stars} ⭐</span>

--- a/src/node_modules/resources/helpers.js
+++ b/src/node_modules/resources/helpers.js
@@ -26,12 +26,8 @@ export function timeSince(date) {
     return interval + " days";
   }
   interval = Math.floor(seconds / 3600);
-  if (interval > 1) {
-    return interval + " hours";
+  if (interval > 24) {
+    return "yesterday";
   }
-  interval = Math.floor(seconds / 60);
-  if (interval > 1) {
-    return interval + " minutes";
-  }
-  return Math.floor(seconds) + " seconds";
+  return "today";
 }


### PR DESCRIPTION
This changes the displayed text for `resource.last_updated` from examples like "15 minutes ago" and "40 hours ago" to "today" and "yesterday", respectively. Since these values are updated daily this seems correct enough. I don't like how the `getUpdatedText` function looks at the string to add "ago", but I didn't want to change `timeSince` to include "ago", and I didn't want to parse the hour count from the previous version of `timeSince` to distinguish between yesterday and today. I'm happy to make changes.

old:
![time_old](https://user-images.githubusercontent.com/2608646/78462525-9ed3ab00-7698-11ea-9a9b-2d09a8a47666.png)

new:
![time_new](https://user-images.githubusercontent.com/2608646/78462528-a2ffc880-7698-11ea-817f-3a0f4ec26126.png)
