### PR TITLE
Add 'Who is using Sapper' folder

### DIFF
--- a/whos-using-sapper/WhosUsingSapper.svelte
+++ b/whos-using-sapper/WhosUsingSapper.svelte
@@ -1,0 +1,48 @@
+<!--
+	Instructions for adding new logos:
+
+	* Fork this repo, and clone your fork
+	* Create a branch called e.g. `add-myorganisation-logo`
+	* Add the logo to the `organisations` directory (preferably SVG)
+	* Add a new <a> tag in this component, in alphabetical order
+	* Create a pull request. Thanks!
+-->
+
+<style>
+	.logos {
+		margin: 1em 0 0 0;
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	a {
+		height: 40px;
+		margin: 0 0.5em 0.5em 0;
+		display: flex;
+		align-items: center;
+		border: 2px solid var(--second);
+		padding: 5px 10px;
+		border-radius: 20px;
+		color: var(--text);
+	}
+
+	.add-yourself {
+		color: var(--prime);
+	}
+
+	picture,
+	img {
+		height: 100%;
+	}
+
+	@media (min-width: 540px) {
+		a {
+			height: 60px;
+			padding: 10px 20px;
+			border-radius: 30px;
+		}
+	}
+</style>
+
+<div class="logos">
+</div>


### PR DESCRIPTION
Adds a folder to gather links and logos for a _Who's using Sapper_ section as described in https://github.com/sveltejs/sapper/issues/1113