### PR TITLE
Call to action on 'Who is using Sapper'

### DIFF
--- a/whos-using-sapper/WhosUsingSapper.svelte
+++ b/whos-using-sapper/WhosUsingSapper.svelte
@@ -45,4 +45,5 @@
 </style>
 
 <div class="logos">
+<a target="_blank" rel="noopener" href="https://github.com/sveltejs/community/blob/master/whos-using-sapper/WhosUsingSapper.svelte" class="add-yourself"><span>+ your company?</span></a>
 </div>


### PR DESCRIPTION
Seems I was too fast with the previous PR, the `+ your company?` link was missing. 
