### PR TITLE
Fix  og images url by removing new line characters

### DIFF
--- a/src/node_modules/components/Head.svelte
+++ b/src/node_modules/components/Head.svelte
@@ -10,44 +10,38 @@
       description:
         "Svelte community meetups, packages, resources, recipes, showcase websites, and more",
       url: `${siteDomain}/`,
-      ogImage: `${siteDomain}/images/og_image_index.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_index.jpg`
     },
     "/events": {
       title: "Events • Svelte Community",
       description:
         "Listing Svelte-related community events and conferences that you can go to.",
       url: `${siteDomain}/events`,
-      ogImage: `${siteDomain}/images/og_image_events.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_events.jpg`
     },
     "/resources": {
       title: "Resources • Svelte Community",
       description: "Useful Svelte related online resources",
       url: `${siteDomain}/code`,
-      ogImage: `${siteDomain}/images/og_image_resources.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_resources.jpg`
     },
     "/recipes": {
       title: "Recipes • Svelte Community",
       description: "Recipes page wip",
       url: `${siteDomain}/code`,
-      ogImage: `${siteDomain}/images/og_image_recipes.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_recipes.jpg`
     },
     "/code": {
       title: "Code • Svelte Community",
       description: "Svelte's libraries and boilerplates using",
       url: `${siteDomain}/code`,
-      ogImage: `${siteDomain}/images/og_image_code.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_code.jpg`
     },
     "/showcase": {
       title: "Showcase • Svelte Community",
       description: "High quality sites and categories built by Svelte.",
       url: `${siteDomain}/showcase`,
-      ogImage: `${siteDomain}/images/og_image_showcase.jpg
-      `
+      ogImage: `${siteDomain}/images/og_image_showcase.jpg`
     },
     "/404": {
       title: "404 • Svelte Community"
@@ -58,13 +52,19 @@
 </script>
 
 <svelte:head>
+  <!-- Primary Meta Tags -->
   <title>{metaData[path].title}</title>
-  <meta property="og:title" content={metaData[path].title} />
-  <meta property="og:url" content={metaData[path].url} />
-  <meta property="og:type" content="website" />
+  <meta name="title" content={metaData[path].title} />
   <meta name="Description" content={metaData[path].description} />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content={metaData[path].url} />
+  <meta property="og:title" content={metaData[path].title} />
   <meta property="og:description" content={metaData[path].description} />
   <meta property="og:image" content={metaData[path].ogImage} />
+
+  <!-- Twitter -->
   <meta name="twitter:title" value={metaData[path].title} />
   <meta name="twitter:description" value={metaData[path].description} />
   <meta name="twitter:image" content={metaData[path].ogImage} />


### PR DESCRIPTION
After checking https://metatags.io/ I found out I made a typo that prevented the og images from showing up!
Fixed that, sorry for the inconvenience I know you are very busy right now!