### PR TITLE
Fix PlentyOfPlans Logo

### DIFF
--- a/whos-using-svelte/WhosUsingSvelte.svelte
+++ b/whos-using-svelte/WhosUsingSvelte.svelte
@@ -101,7 +101,7 @@
 	<a target="_blank" rel="noopener" href="https://paperform.co"><img src="organisations/paperform.svg" alt="Paperform logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://www.phonerefer.com"><img src="organisations/phonerefer.png" alt="PhoneRefer logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://www.playpilot.com/"><img src="organisations/playpilot-logo.svg" alt="Playpilot logo" loading="lazy"></a>
-	<a target="_blank" rel="noopener" href="https://en.plentyofplans.app"><img src="organisations/plentyofplans.png" alt="PlentyOfPlans logo" loading="lazy"></a>
+	<a target="_blank" rel="noopener" href="https://en.plentyofplans.app"><img src="organisations/plentyofplans.svg" alt="PlentyOfPlans logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://pqina.nl"><img src="organisations/pqina.svg" alt="PQINA logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://profullstack.com"><img src="organisations/profullstack.svg" alt="Profullstack logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://global.rakuten.com/corp/"><img src="organisations/rakuten.svg" alt="Rakuten logo" loading="lazy"></a>


### PR DESCRIPTION
Using the wrong file extension yielded a broken image on the homepage falling back on the alt tag.