### PR TITLE
Add svelte-monetization component package

### DIFF
--- a/data/code.yml
+++ b/data/code.yml
@@ -2046,3 +2046,11 @@ resources:
     stars: 6
     last_updated: '2020-05-11T18:35:41Z'
     downloads: 812
+  - name: '`svelte-monetization`'
+    url: 'https://github.com/sorxrob/svelte-monetization'
+    description: A minimal and lightweight wrapper for the Web Monetization API
+    tags:
+      - components and libraries
+    stars: 4
+    last_updated: '2020-05-15T00:58:06.606Z'
+    downloads: 53


### PR DESCRIPTION
Hello. Adding my first svelte package. It is a component wrapper for the [Web Monetization API](https://webmonetization.org/).

Web Monetization is being proposed as a W3C standard at the [Web Platform Incubator Community Group](https://discourse.wicg.io/t/proposal-web-monetization-a-new-revenue-model-for-the-web/3785). It is a JavaScript browser API which allows the creation of a payment stream from the user agent to the website.