### PR TITLE
Add Elder Guide to "Who's Using Svelte"

### DIFF
--- a/whos-using-svelte/WhosUsingSvelte.svelte
+++ b/whos-using-svelte/WhosUsingSvelte.svelte
@@ -68,6 +68,7 @@
 	<a target="_blank" rel="noopener" href="https://db.nomics.world" style="background-color: #0f272f;"><picture><source type="image/webp" srcset="organisations/dbnomics.webp"><img src="organisations/dbnomics.jpg" alt="DBNomics logo" loading="lazy"></picture></a>
 	<a target="_blank" rel="noopener" href="https://deck.nl"><img src="organisations/deck.svg" alt="Deck logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://dextra.com.br/pt/"><img src="organisations/dextra.png" alt="Dextra logo" loading="lazy"></a>
+	<a target="_blank" rel="noopener" href="https://elderguide.com/"><img src="organisations/elderguide.svg" alt="Elder Guide logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://www.entriwise.com/"><img src="organisations/entriwise.png" alt="Entriwise logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://www.entur.org/about-entur/" style="background-color: #191954;"><img src="organisations/entur.svg" alt="Entur logo" loading="lazy"></a>
 	<a target="_blank" rel="noopener" href="https://www.etherbit.dev/"><img src="organisations/etherbit-dev.svg" alt="Etherbit Dev logo" loading="lazy"></a>

--- a/whos-using-svelte/organisations/elderguide.svg
+++ b/whos-using-svelte/organisations/elderguide.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="318px" height="68px" viewBox="0 0 318 68" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>Slice 1</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" font-family="Georgia" font-size="60" font-weight="normal">
+        <text id="Elder-Guide" fill="#154462">
+            <tspan x="0" y="55">Elder Guide</tspan>
+        </text>
+    </g>
+</svg>


### PR DESCRIPTION
We've been loving using Svelte. Built our own internal SSG as Sapper couldn't handle our 2B+ data points and the way we needed to fetch them. 

Every page has 1-5 Svelte components depending on what needed to be hydrated or not. Ones we are most proud of are our interactive map (https://elderguide.com/new-york/new-york-nursing-homes/) or our interactive calendar/graphs (https://elderguide.com/senior-living/the-pavilion-at-creekwood-76063/).

Svelte was chosen because SEO is of the upmost importance for this site and we were able to achieve things we never thought possible. 

You all rock. <3