### PR TITLE
Add svelte range slider pips

### DIFF
--- a/data/code.yml
+++ b/data/code.yml
@@ -2296,3 +2296,13 @@ resources:
     stars: 9
     last_updated: '2020-05-22T15:18:25Z'
     downloads: 812
+  - name: '`svelte-range-slider-pips`'
+    url: 'svelte-range-slider-pips'
+    description: Range Slider Input, with Multi-handle and Pips features
+    tags:
+      - components and libraries
+      - inputs and widgets
+      - forms and validation
+      - interaction
+    stars: 2
+    last_updated: '2020-07-26T13:40:26Z'


### PR DESCRIPTION
Add this component/widget https://github.com/simeydotme/svelte-range-slider-pips to the list.

I couldn't figure out any kind of ordering/hierarchy, and I don't know how to get the `downloads` count?