### PR TITLE
fix: showcase is failing on 500 error

### DIFF
--- a/src/routes/showcase.svelte
+++ b/src/routes/showcase.svelte
@@ -93,9 +93,9 @@
         <div class="SiteCard-Metadata">
           <div class="SiteCard-Metadata-Desc">{site.description}</div>
           <div class="SiteCard-Metadata-Labels">
-            {#each site.tags as tag}
-              <span>{tag}</span>
-            {/each}
+            {#if Array.isArray(sites.tags)}
+              {#each site.tags as tag}<span>{tag}</span>{/each}
+            {/if}
           </div>
           <div class="SiteCard-Metadata-Links">
             {#if site.source}


### PR DESCRIPTION
### What's in there?

- [x] fix: showcase page is failing on 500 error

![image](https://user-images.githubusercontent.com/186268/97965818-3ded8c00-1dbb-11eb-8c04-765b0430cb5a.png)

### How to test?

- checkout branch
- run `npm start`
- go to http://localhost:3000/showcase
![image](https://user-images.githubusercontent.com/186268/97965918-607fa500-1dbb-11eb-92a0-94c2e62c08d6.png)

### Notes to reviewers

I would have prefered to ensure that returned sites always have a tags array (possibly empty), but the way `[ssgData].json.js` is written does not encourage route-specific code.
Hence why I've fixed it directly in the view.