### PR TITLE
Redirect to Svelte Society website

### DIFF
--- a/src/routes/code.svelte
+++ b/src/routes/code.svelte
@@ -1,7 +1,9 @@
 <script context="module">
   export async function preload() {
-    const data = await this.ssgData({ key: "code" });
-    return { data };
+    return this.redirect(301, 'https://sveltesociety.dev/components');
+//    const data = await this.ssgData({ key: "code" });
+//    return { data };
+
   }
 </script>
 

--- a/src/routes/events.svelte
+++ b/src/routes/events.svelte
@@ -1,3 +1,9 @@
+<script context="module">
+  export async function preload() {
+    return this.redirect(301, 'https://sveltesociety.dev/events');
+  }
+</script>
+
 <script>
   import { Hero, Blurb } from "@sveltejs/site-kit";
   import Event from "components/Event.svelte";

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,3 +1,9 @@
+<script context="module">
+  export async function preload() {
+    return this.redirect(301, 'https://sveltesociety.dev/');
+  }
+</script>
+
 <script>
   import { Hero, Blurb } from "@sveltejs/site-kit";
 
@@ -12,10 +18,6 @@
     });
   }
 </script>
-
-<style>
-
-</style>
 
 <Hero
   title="Svelte Community"

--- a/src/routes/recipes.svelte
+++ b/src/routes/recipes.svelte
@@ -1,10 +1,15 @@
+<script context="module">
+  export async function preload() {
+    return this.redirect(301, 'https://sveltesociety.dev/recipes');
+//    const data = await this.ssgData({ key: "code" });
+//    return { data };
+
+  }
+</script>
+
 <script>
   import { Hero, Blurb } from "@sveltejs/site-kit";
 </script>
-
-<style>
-
-</style>
 
 <Hero
   title="Svelte Community"

--- a/src/routes/resources.svelte
+++ b/src/routes/resources.svelte
@@ -1,8 +1,9 @@
 <script context="module">
   export async function preload() {
-    const res = await this.fetch(`data/resources___ssg___index.json`);
-    const data = await res.json();
-    return { data };
+    return this.redirect(301, 'https://sveltesociety.dev/cheatsheet');
+//    const res = await this.fetch(`data/resources___ssg___index.json`);
+//    const data = await res.json();
+//    return { data };
   }
 </script>
 

--- a/src/routes/showcase.svelte
+++ b/src/routes/showcase.svelte
@@ -1,7 +1,8 @@
 <script context="module">
   export async function preload() {
-    const data = await this.ssgData({ key: "showcase" });
-    return { sites: data.sites };
+    return this.redirect(301, 'https://svelte.dev/');
+//    const data = await this.ssgData({ key: "showcase" });
+//    return { sites: data.sites };
   }
 </script>
 


### PR DESCRIPTION
As requested in https://github.com/sveltejs/community/issues/281

The showcase and resources pages didn't exactly exist on SvelteSociety.dev. I redirected showcase to svelte.dev since it has the "who is using svelte" section. I redirected resources to the cheatsheet since it was the closest alternative